### PR TITLE
Update codeowners to reference Liberty team [OE-32]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ezcater/liberty


### PR DESCRIPTION
## What did we change?

Updated codeowners file to use liberty team

## Why are we doing this?

Ensuring that our codeowners file is accurate, and making it easier to change in the future. We're doing this for all Liberty owned repos.